### PR TITLE
feat: add marker for the search matching

### DIFF
--- a/kanban-app/src/app/app-routing.module.ts
+++ b/kanban-app/src/app/app-routing.module.ts
@@ -16,7 +16,7 @@ const routes: Routes = [
     canActivate: [AuthGuard],
   },
   {
-    path: 'board/:id',
+    path: 'board/:id/:columnId',
     loadChildren: () =>
       import('./pages/board-page/board-page.module').then(
         m => m.BoardPageModule

--- a/kanban-app/src/app/developers-ru.ts
+++ b/kanban-app/src/app/developers-ru.ts
@@ -10,7 +10,7 @@ export const DEVELOPERS_RU: DEVELOPER[] = [
     features: [],
     alt: '',
     aboutAuthor:
-      "Hello! My name is Alexander Malchevsky. I like programming so much and I live by the principle: not a day without coding.This is our course project. I hope you'll like it!",
+      "Привет! Немного о себе, у меня три страсти: путешествия, автомобили и программирование. Третья страсть самая сильная. Я обожаю кодить, и не важно какой это проект, финальный таск по Ангуляр или какой-то рядовой, не важно какой это язык, Java Script или Python, я просто люблю это и отдаю этому всего себя.",
   },
   {
     id: 3,

--- a/kanban-app/src/app/developers.ts
+++ b/kanban-app/src/app/developers.ts
@@ -18,7 +18,7 @@ export const DEVELOPERS: DEVELOPER[] = [
     features: [],
     alt: '',
     aboutAuthor:
-      "Hello! My name is Alexander Malchevsky. I like programming so much and I live by the principle: not a day without coding.This is our course project. I hope you'll like it!",
+      "Hello! A little about myself, I have three passions: traveling, cars and programming. The third passion is the strongest. I love coding, and no matter what project it is, the final task for Angular or some ordinary one, no matter what language it is, Java Script or Python, I just love it and give it my all.",
   },
   {
     id: 3,

--- a/kanban-app/src/app/pages/board-page/board-page/board-page.component.html
+++ b/kanban-app/src/app/pages/board-page/board-page/board-page.component.html
@@ -1,5 +1,6 @@
 <h1>Board</h1>
 <h2>ID: {{ id }}</h2>
+<h2>ColumnID: {{ columnId }}</h2>
 <section class="column-wrapper">
   <section
     class="columns"
@@ -25,4 +26,4 @@
     {{ 'BOARD.addNewColumn' | translate }}
   </button>
 </section>
-<button [routerLink]="['../../main']">BACK to BOARDS</button>
+<button [routerLink]="['../../../main']">BACK to BOARDS</button>

--- a/kanban-app/src/app/pages/board-page/board-page/board-page.component.ts
+++ b/kanban-app/src/app/pages/board-page/board-page/board-page.component.ts
@@ -23,6 +23,7 @@ import { selectConfirmationResult } from 'src/app/redux/selectors/confirmation.s
 export class BoardPageComponent implements OnInit, OnDestroy {
   result$ = this.store.select(selectConfirmationResult);
   id: string = '';
+  columnId: string | undefined = '';
   subscription?: Subscription;
   currentBoard$?: Observable<Board | undefined>;
   currentColumns$?: Observable<Column | undefined>;
@@ -42,8 +43,12 @@ export class BoardPageComponent implements OnInit, OnDestroy {
         this.store.dispatch(loadColumns({ id: this.id }));
         this.currentBoard$ = this.store.select(selectBoardById(this.id));
       });
+    this.route.paramMap
+      .pipe(switchMap(params => params.getAll('columnId')))
+      .subscribe(data => {
+        this.columnId = data;
+      });
   }
-
   createColumn() {
     this.modalService.setExtra([this.id]);
     this.modalService.setScheme(ModalSchemes.addColumn);

--- a/kanban-app/src/app/pages/main/components/board/board.component.html
+++ b/kanban-app/src/app/pages/main/components/board/board.component.html
@@ -4,48 +4,42 @@
   class="board-container">
   <mat-card-header
     class="inner-container"
-    [routerLink]="['../board', board?.id]">
+    [routerLink]="['../board', board?.id, 'undefined']">
     <mat-card-title
       class="title"
-      [innerHTML]="board?.title! | mark: searchRequest">
+      [innerHTML]="(board?.title! | mark: searchRequest) + '(' + length + ')'">
     </mat-card-title>
     <mat-card-subtitle
       [innerHTML]="
         (board?.description! | mark: searchRequest) + '...'
       "></mat-card-subtitle>
   </mat-card-header>
-  <div class="toggle" *ngIf="length! > 0">
-    <span>{{ 'columns' | translate }}({{ length }})</span>
-    <div mou class="icons">
-      <mat-icon *ngIf="isPreview === false">unfold_more</mat-icon>
-      <mat-icon *ngIf="isPreview">unfold_less</mat-icon>
-    </div>
-  </div>
   <mat-card-content
     *ngIf="length! > 0 && isPreview"
     class="container-preview"
-    [routerLink]="['../board', board?.id]"
     [class.visible]="length! > 0 && isPreview">
-    <div class="column-item" *ngFor="let column of columns | order">
-      <mat-card-subtitle
-        [innerHTML]="
-          column.order +
-          (column?.title! | mark: searchRequest)+
-          '...'
-        ">
-      </mat-card-subtitle>
-      <div class="tasks-container">
-        <mat-card-subtitle *ngIf="column.tasks?.length! > 0"
-          >tasks:</mat-card-subtitle
-        >
+    <div class="inner-container-preview" [class.full]="columns!.length > 3">
+      <div
+        class="column-item"
+        *ngFor="let column of columns | order"
+        [routerLink]="['../board', board?.id, column?.id]">
         <mat-card-subtitle
-          *ngFor="let task of column.tasks"
+          class="column-title"
           [innerHTML]="
-            task.order +
-            (task?.title! | mark: searchRequest) +
-            '...'
+            column.order + '. ' + (column?.title! | mark: searchRequest) + '...'
           ">
         </mat-card-subtitle>
+        <div class="tasks-container">
+          <mat-card-subtitle *ngIf="column.tasks?.length! > 0"
+            >tasks:</mat-card-subtitle
+          >
+          <mat-card-subtitle
+            *ngFor="let task of column.tasks"
+            [innerHTML]="
+              task.order + '. ' + (task?.title! | mark: searchRequest) + '...'
+            ">
+          </mat-card-subtitle>
+        </div>
       </div>
     </div>
   </mat-card-content>

--- a/kanban-app/src/app/pages/main/components/board/board.component.html
+++ b/kanban-app/src/app/pages/main/components/board/board.component.html
@@ -1,15 +1,22 @@
-<mat-card class="board-container">
+<mat-card
+  (mouseenter)="toggle()"
+  (mouseleave)="toggle()"
+  class="board-container">
   <mat-card-header
     class="inner-container"
     [routerLink]="['../board', board?.id]">
-    <mat-card-title class="title">
-      {{ board?.title }}
+    <mat-card-title
+      class="title"
+      [innerHTML]="board?.title! | mark: searchRequest">
     </mat-card-title>
-    <mat-card-subtitle>{{ board?.description }}...</mat-card-subtitle>
+    <mat-card-subtitle
+      [innerHTML]="
+        (board?.description! | mark: searchRequest) + '...'
+      "></mat-card-subtitle>
   </mat-card-header>
-  <div class="toggle" (click)="toggle()" *ngIf="length! > 0">
+  <div class="toggle" *ngIf="length! > 0">
     <span>{{ 'columns' | translate }}({{ length }})</span>
-    <div class="icons">
+    <div mou class="icons">
       <mat-icon *ngIf="isPreview === false">unfold_more</mat-icon>
       <mat-icon *ngIf="isPreview">unfold_less</mat-icon>
     </div>
@@ -21,14 +28,23 @@
     [class.visible]="length! > 0 && isPreview">
     <div class="column-item" *ngFor="let column of columns | order">
       <mat-card-subtitle
-        >{{ column.order }}. {{ column.title.slice(0, 10) }}...
+        [innerHTML]="
+          column.order +
+          (column?.title! | mark: searchRequest)+
+          '...'
+        ">
       </mat-card-subtitle>
       <div class="tasks-container">
         <mat-card-subtitle *ngIf="column.tasks?.length! > 0"
           >tasks:</mat-card-subtitle
         >
-        <mat-card-subtitle *ngFor="let task of column.tasks">
-          {{ task.order }}. {{ task.title.slice(0, 10) }}...
+        <mat-card-subtitle
+          *ngFor="let task of column.tasks"
+          [innerHTML]="
+            task.order +
+            (task?.title! | mark: searchRequest) +
+            '...'
+          ">
         </mat-card-subtitle>
       </div>
     </div>

--- a/kanban-app/src/app/pages/main/components/board/board.component.scss
+++ b/kanban-app/src/app/pages/main/components/board/board.component.scss
@@ -63,6 +63,8 @@
   justify-content: flex-start;
   align-items: flex-start;
   border-radius: 5px;
+  &:hover{transform: scale(1.05);
+  }
 }
 button {
   position: absolute;
@@ -77,13 +79,12 @@ button {
   top: 100px;
   width: 50px;
   height: 50px;
-  cursor: pointer;
   color: $moreColor;
 }
 .visible {
   opacity: 1;
   visibility: visible;
-  left: 330px;
+  left: 320px;
 }
 .icons {
   transform: rotate(90deg);

--- a/kanban-app/src/app/pages/main/components/board/board.component.scss
+++ b/kanban-app/src/app/pages/main/components/board/board.component.scss
@@ -26,6 +26,10 @@
   justify-content: center;
   overflow-wrap: break-word;
   padding-bottom: 10px;
+
+  &:hover .title{
+    color: $moreColor;
+  }
 }
 .container-preview {
   position: absolute;
@@ -54,8 +58,9 @@
   justify-content: center;
   align-items: center;
   width: 110px;
-  overflow-wrap: break-word;
-  height: 200px;
+  gap:10px;
+  word-break:break-all;
+  height: 190px;
   border: 1px solid $whiteBorderColor;
   background-color: $boardBackgroundColor;
   padding-left: 5px;
@@ -63,9 +68,18 @@
   justify-content: flex-start;
   align-items: flex-start;
   border-radius: 5px;
-  &:hover{transform: scale(1.05);
+  opacity: 0.8;
+  cursor: pointer;
+  &:hover {
+    opacity: 1;
+    border-color: $moreColor;
+  };
+  &:hover .column-title {
+    color: $moreColor;
+    
   }
 }
+
 button {
   position: absolute;
   top: 160px;
@@ -89,11 +103,23 @@ button {
 .icons {
   transform: rotate(90deg);
 }
-.tasks-container{
+.tasks-container {
   display: flex;
   flex-direction: column;
-  width:105px;
-  height:150px;
+  width: 105px;
+  height: 150px;
   background-color: #f5f5f5;
   overflow-y: auto;
+}
+.inner-container-preview {
+  display: flex;
+  transition: 1s;
+}
+.column-title{
+  word-wrap: break-word;
+  margin-top: 10px;
+}
+mark{
+  background-color: $moreColor;
+  color: #f5f5f5;
 }

--- a/kanban-app/src/app/pages/main/components/board/board.component.ts
+++ b/kanban-app/src/app/pages/main/components/board/board.component.ts
@@ -20,6 +20,7 @@ import { selectConfirmationResult } from 'src/app/redux/selectors/confirmation.s
 export class BoardComponent implements OnDestroy, OnInit {
   subscription?: Subscription;
   @Input() board?: Board;
+  @Input() searchRequest: string = '';
   result$ = this.store.select(selectConfirmationResult);
   columns?: Column[];
   length: number | undefined;

--- a/kanban-app/src/app/pages/main/main.component.html
+++ b/kanban-app/src/app/pages/main/main.component.html
@@ -17,7 +17,8 @@
     ">
     <app-board
       *ngFor="let item of (boards$ | async)! | search: searchRequest"
-      [board]="item">
+      [board]="item"
+      [searchRequest]="searchRequest">
     </app-board>
   </div>
 </div>

--- a/kanban-app/src/app/pages/main/main.component.scss
+++ b/kanban-app/src/app/pages/main/main.component.scss
@@ -1,3 +1,5 @@
+@import '../../colors.scss';
+
 input:focus {
   outline: 0;
   border: transparent;
@@ -15,6 +17,7 @@ input:focus {
   height: auto;
   min-height: 300px;
   min-width: 300px;
+  margin-bottom: 50px;
 }
 .inner-container {
   display: flex;
@@ -33,6 +36,7 @@ input:focus {
   background-color: #eee;
   border: transparent;
   z-index: 0;
+  color: $moreColor;
 }
 .title {
   position: sticky;

--- a/kanban-app/src/app/shared/pipes/mark.pipe.spec.ts
+++ b/kanban-app/src/app/shared/pipes/mark.pipe.spec.ts
@@ -1,0 +1,8 @@
+import { MarkPipe } from './mark.pipe';
+
+describe('MarkPipe', () => {
+  it('create an instance', () => {
+    const pipe = new MarkPipe();
+    expect(pipe).toBeTruthy();
+  });
+});

--- a/kanban-app/src/app/shared/pipes/mark.pipe.ts
+++ b/kanban-app/src/app/shared/pipes/mark.pipe.ts
@@ -1,0 +1,20 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+@Pipe({
+  name: 'mark',
+})
+export class MarkPipe implements PipeTransform {
+  transform(input: string, search: string) {
+    let output = input;
+
+    if (search.trim() === '') {
+      return output;
+    } else {
+      let matching = input.match(RegExp(search, 'i')) || [''];
+      return output.replace(
+        RegExp(matching![0], 'gi'),
+        `<mark>${matching![0]}</mark>`
+      );
+    }
+  }
+}

--- a/kanban-app/src/app/shared/shared.module.ts
+++ b/kanban-app/src/app/shared/shared.module.ts
@@ -9,10 +9,11 @@ import { MatDialogModule } from '@angular/material/dialog';
 import { MatButtonModule } from '@angular/material/button';
 import { SearchPipe } from './pipes/search.pipe';
 import { OrderPipe } from './pipes/oder.pipe';
+import { MarkPipe } from './pipes/mark.pipe';
 
 @NgModule({
-  declarations: [ConfirmDialogComponent, SearchPipe, OrderPipe],
+  declarations: [ConfirmDialogComponent, SearchPipe, OrderPipe, MarkPipe],
   imports: [CommonModule, TranslateModule, MatDialogModule, MatButtonModule],
-  exports: [SearchPipe, OrderPipe],
+  exports: [SearchPipe, OrderPipe, MarkPipe],
 })
 export class SharedModule {}


### PR DESCRIPTION
![Screenshot_20221110_015323](https://user-images.githubusercontent.com/91604689/200959951-a6af64e3-ec04-4aca-a868-48b8fe7d6f68.png)
 
 Добавлен маркер совпадений поиска по всем полям, открытие доп. информации по борду теперь происходит при mouseenter событии, то есть при наведении. Добавлен  дополнительный параметр для маршрута board (Ваня обрати внимание), кроме id  борда теперь передается еще и id колонки. это позволит при переходе из main route по клику на колонку переходить по маршруту board  и уже как-то выделять нужную колонку.