### PR TITLE
fix:fix some bugs with scroll navigation

### DIFF
--- a/kanban-app/src/app/core/services/scroll.service.ts
+++ b/kanban-app/src/app/core/services/scroll.service.ts
@@ -6,13 +6,22 @@ import { BehaviorSubject } from 'rxjs';
 })
 export class ScrollService {
   onScroll$$ = new BehaviorSubject(0);
-  scrollHeight$$ = new BehaviorSubject(document.body.scrollHeight);
+  scrollHeight$$ = new BehaviorSubject(0);
   constructor() {
     document.addEventListener('scroll', () => {
-      this.scrollHeight$$.next(document.body.scrollHeight);
+      this.scrollHeight$$.next(
+        document.body.scrollHeight - document.body.offsetHeight
+      );
+      this.onScroll$$.next(window.pageYOffset);
+    });
+    document.addEventListener('mousemove', () => {
+      this.scrollHeight$$.next(
+        document.body.scrollHeight - document.body.offsetHeight
+      );
       this.onScroll$$.next(window.pageYOffset);
     });
   }
+  
   getPositionY() {
     return this.onScroll$$;
   }

--- a/kanban-app/src/app/pages/main/components/custom-board/custom-board.component.spec.ts
+++ b/kanban-app/src/app/pages/main/components/custom-board/custom-board.component.spec.ts
@@ -8,9 +8,8 @@ describe('CustomBoardComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [ CustomBoardComponent ]
-    })
-    .compileComponents();
+      declarations: [CustomBoardComponent],
+    }).compileComponents();
 
     fixture = TestBed.createComponent(CustomBoardComponent);
     component = fixture.componentInstance;

--- a/kanban-app/src/app/pages/main/components/select-board-dialog/select-board-dialog.component.spec.ts
+++ b/kanban-app/src/app/pages/main/components/select-board-dialog/select-board-dialog.component.spec.ts
@@ -8,9 +8,8 @@ describe('SelectBoardDialogComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [ SelectBoardDialogComponent ]
-    })
-    .compileComponents();
+      declarations: [SelectBoardDialogComponent],
+    }).compileComponents();
 
     fixture = TestBed.createComponent(SelectBoardDialogComponent);
     component = fixture.componentInstance;

--- a/kanban-app/src/app/pages/main/main.component.html
+++ b/kanban-app/src/app/pages/main/main.component.html
@@ -5,7 +5,9 @@
       <mat-icon *ngIf="(posY$$ | async) !== 0" (click)="scrollUp()"
         >keyboard_double_arrow_up</mat-icon
       >
-      <mat-icon *ngIf="checkDown((posY$$ | async)!)" (click)="scrollDown()"
+      <mat-icon
+        *ngIf="(posY$$ | async)! - (scrollHeight$$ | async)! < 0"
+        (click)="scrollDown()"
         >keyboard_double_arrow_down</mat-icon
       >
     </nav>

--- a/kanban-app/src/app/pages/main/main.component.scss
+++ b/kanban-app/src/app/pages/main/main.component.scss
@@ -240,11 +240,17 @@ input:focus {
   display: flex;
   flex-direction: column;
   gap: 20px;
+  z-index: 20;
   & mat-icon {
     cursor: pointer;
     opacity: .5;
     &:hover{
       opacity: 1;
     }
+  }
+}
+@media (max-width: 400px) {
+  .navigation{
+    visibility: hidden;
   }
 }

--- a/kanban-app/src/app/pages/main/main.component.ts
+++ b/kanban-app/src/app/pages/main/main.component.ts
@@ -210,5 +210,4 @@ export class MainComponent implements OnInit, OnDestroy {
   scrollUp() {
     window.scrollTo(0, 0);
   }
-  checkDown = (pos: number = 0) => pos <= document.body.scrollHeight * 0.7;
 }


### PR DESCRIPTION
Исправлены недочеты в работе быстрых кнопок скролла:
1. при уменьшении width в какой-то момент кнопки находились ниже слоем и соответственно не реагировали, увеличил z-index;
2. неадекватно работало определение нижней точки скролла, исправлено;
3. при width<400px кнопки начинали заходить на карточки бордов, исправлено отключением через медиа запрос.